### PR TITLE
Update Formula to version 1.3.0

### DIFF
--- a/Formula/fabric-tools.rb
+++ b/Formula/fabric-tools.rb
@@ -5,8 +5,9 @@
 class FabricTools < Formula
   desc "Hyperledger Fabric native binaries installer"
   homepage "https://hyperledger.org/projects/fabric"
-  url "https://nexus.hyperledger.org/content/repositories/releases/org/hyperledger/fabric/hyperledger-fabric/darwin-amd64-1.1.0/hyperledger-fabric-darwin-amd64-1.1.0.tar.gz"
-  sha256 "46bee0ddf51d6e47fac6b59906b2ea2e738194e92f0642c9b6fa0a0ad31077dd"
+  url "https://nexus.hyperledger.org/content/repositories/releases/org/hyperledger/fabric/hyperledger-fabric/darwin-amd64-1.3.0/hyperledger-fabric-darwin-amd64-1.3.0.tar.gz"
+  version "1.3.0"
+  sha256 "8580b49c651c0db1956b8a1147be1554b3a2bfcf91350e38038f977aa515c9fb"
 
   def install
     bin.install "bin/cryptogen"


### PR DESCRIPTION
Hi Hyperledger Community,

This is a small PR to update the Homebrew Formula to install Fabric Tools (cryptogen, configtx ...) to the latest version (1.3.0).

I added the version to the Formula to easily install a specific version.

It might be interesting to update automatically this formula when a new release is published in the future.

Nicolas